### PR TITLE
Pin MarkupSafe to 2.0.1 for compatibility with Jinja2 2.x.

### DIFF
--- a/backends/flask-sqlalchemy-oso/requirements.txt
+++ b/backends/flask-sqlalchemy-oso/requirements.txt
@@ -1,3 +1,4 @@
 flask~=1.1.4
+MarkupSafe==2.0.1
 SQLAlchemy~=1.3.20
 sqlalchemy-oso==0.25.1

--- a/backends/flask-sqlalchemy/requirements.txt
+++ b/backends/flask-sqlalchemy/requirements.txt
@@ -1,3 +1,4 @@
 flask~=1.1.4
+MarkupSafe==2.0.1
 SQLAlchemy~=1.3.20
 oso==0.25.1


### PR DESCRIPTION
Fixes osohq/gitclub#47

This fixes the markupsafe errors in the flask-sqlalchemy and flask-sqlalchemy-oso backends while maintaining the current version constraint on Jinja2.